### PR TITLE
Improve/error response

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,10 @@ function request (params, fn) {
 
   // start the request
   req.end(function (err, res){
-    if (err) return fn(err);
+    if (err && !res) {
+      return fn(err);
+    }
+
     var body = res.body;
     var headers = res.headers;
     var statusCode = res.status;
@@ -95,17 +98,21 @@ function request (params, fn) {
       body._headers = headers;
     }
 
-    if (2 === Math.floor(statusCode / 100)) {
-      // 2xx status code, success
-      fn(null, body);
-    } else {
-      // any other status code is a failure
-      err = new Error();
-      err.statusCode = statusCode;
-      for (var i in body) err[i] = body[i];
-      if (body && body.error) err.name = toTitle(body.error) + 'Error';
-      fn(err);
+    if (!err) {
+      return fn(null, body);
     }
+
+    err = new Error();
+    err.statusCode = statusCode;
+    for (var i in body) {
+      err[i] = body[i];
+    }
+
+    if (body && body.error) {
+      err.name = toTitle(body.error) + 'Error';
+    }
+
+    fn(err);
   });
 
   return req.xhr;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "debug": "~2.1.0",
-    "superagent": "1.1.0"
+    "superagent": "1.2.0"
   }
 }


### PR DESCRIPTION
This merge https://github.com/visionmedia/superagent/pull/554 in `superagent` changes the way to handler error response in the callback.
With this PR we ensure the same error response like wpcom-xhr-request did it before to bump superagent.

Right now, for instance, for `404` response the error message is `Not found`

![](https://cldup.com/Go1aGbbYHX.png)

it should be `Unknown blog`

![](https://cldup.com/gvZMI5Ye5r.png)