### PR TITLE
Use qs to stringify the query params

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function request (params, fn) {
 
   // URL querystring values
   if (params.query) {
-    req.query(qs.stringify(params.query, { indices: false }));
+    req.query(qs.stringify(params.query, { arrayFormat: 'brackets' }));
     debug('API send URL querystring: %o', params.query);
     delete params.query;
   }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var superagent = require('superagent');
 var debug = require('debug')('wpcom-xhr-request');
+var qs = require('qs');
 
 /**
  * Export a single `request` function.
@@ -63,7 +64,7 @@ function request (params, fn) {
 
   // URL querystring values
   if (params.query) {
-    req.query(params.query);
+    req.query(qs.stringify(params.query, { indices: false }));
     debug('API send URL querystring: %o', params.query);
     delete params.query;
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "debug": "~2.1.0",
+    "qs": "^4.0.0",
     "superagent": "1.2.0"
   }
 }


### PR DESCRIPTION
This fixes a problem with encoding PHP-style query arrays. For example, if you pass:

`urls=[ 'first', 'second', 'third' ]`

It would produce a query string of:

`urls[]=/first,/second,/third`

When the WP.com API expects:

`urls[]=/first&urls[]=/second&urls[]=/third`

This may get fixed in superagent itself as per https://github.com/visionmedia/superagent/issues/670, in which case this can be removed (although it should be harmless)

Also https://github.com/Automattic/wpcom.js/pull/109