### PR TITLE
Set optional request handlers if passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,18 +89,26 @@ function request (params, fn) {
   // optional request handlers
   if ('function' === typeof params.onprogress) {
     req.onprogress = params.onProgress;
+    delete params.onprogress;
   }
   
   if (params.upload && 'function' === typeof params.upload.onprogress) {
     req.upload.onprogress = params.upload.onload;
+    delete params.upload.onprogress;
   }
   
   if (params.upload && 'function' === typeof params.upload.onload) {
     req.upload.onload = params.upload.onload;
+    delete params.upload.onload;
+  }
+  
+  if (params.upload) {
+    delete params.upload;
   }
   
   if ('function' === typeof params.onabort) {
     req.onabort = params.onabort;
+    delete params.onabort;
   }
 
   // start the request

--- a/index.js
+++ b/index.js
@@ -85,6 +85,23 @@ function request (params, fn) {
       req.field(key, value);
     }
   }
+  
+  // optional request handlers
+  if ('function' === typeof params.onprogress) {
+    req.onprogress = params.onProgress;
+  }
+  
+  if (params.upload && 'function' === typeof params.upload.onprogress) {
+    req.upload.onprogress = params.upload.onload;
+  }
+  
+  if (params.upload && 'function' === typeof params.upload.onload) {
+    req.upload.onload = params.upload.onload;
+  }
+  
+  if ('function' === typeof params.onabort) {
+    req.onabort = params.onabort;
+  }
 
   // start the request
   req.end(function (err, res){


### PR DESCRIPTION
Currently the request only returns the final `unload` event at the end of `req.end()`, but there are other important events that occur along the way, such as `onprogress` for both uploading and downloading plus the `onabort` method.

This commit sets those handlers if they are given in the params.

**Note**: From MDN
> Note: You need to add the event listeners before calling open() on the request.  Otherwise the progress events will not fire.