### PR TITLE
GET requests don't support body

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,8 +70,14 @@ function request (params, fn) {
 
   // POST API request body
   if (params.body) {
-    req.send(params.body);
-    debug('API send POST body: ', params.body);
+    // GET requests don't support body; convert to querystring
+    if (method === 'get') {
+      req.query(params.body);
+      debug('API body to URL querystring: ', params.body);
+    } else {
+      req.send(params.body);
+      debug('API send POST body: ', params.body);
+    }
     delete params.body;
   }
 


### PR DESCRIPTION
Be a bit more forgiving by converting any passed in `body` values for GET requests to `query`.

Context: in Calypso, because we use `wpcom-proxy-request`, GET requests with params are built by passing a `body` key. Our iframe proxy converts these into a proper querystring.

When using `oauth` in Calypso, we switch the transport layer to this lib (i.e. `wpcom-xhr-request`) which does not handle the `body` => `query` transformation and we end up with requests with no query params.