### PR TITLE
Add support for WP-API /wp-json endpoints.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ var proxyOrigin = 'https://public-api.wordpress.com';
 var defaultApiVersion = '1';
 
 /**
+ * WP-API Versions
+ */
+var wpApiVersions = ['2'];
+
+/**
  * Performs an XMLHttpRequest against the WordPress.com REST API.
  *
  * @param {Object|String} params
@@ -48,7 +53,14 @@ function request (params, fn) {
   proxyOrigin = params.proxyOrigin || proxyOrigin;
   delete params.proxyOrigin;
 
-  var url = proxyOrigin + '/rest/v' + apiVersion + params.path;
+  var basePath = '/rest/v' + apiVersion;
+
+  // if this is a wp-api request, adjust basePath
+  if ( wpApiVersions.indexOf( apiVersion ) !== -1 ) {
+    basePath = '/wp-json';
+  }
+
+  var url = proxyOrigin + basePath + params.path;
   debug('API URL: %o', url);
   delete params.path;
 


### PR DESCRIPTION
This PR is part of the project to integrate the WP-API with the WordPress.com API.  WP-API endpoints will utilize the following endpoint structure on WordPress.com:

`/wp-json/{ site }/{ namespace }/{ version }/{ endpoint }`

For example a "core" endpoint for post types would be:

`/wp-json/{ site }/wp/v2/types`

There has been some discussion about this URL structure ( and some of its oddities ) already, and here is a quick synopsis that @nylen provided:

```
- /wp-json is the default URL prefix for all REST URLs in core: rest_url_prefix. Everything that uses core’s REST scaffolding has this URL prefix and I think it is best to use the default.
- We need to add /sites/%s because we want to serve requests for all sites from a single domain, rather than from each site’s domain like WP-API does by default.
- wp/v2 is the WP-API namespace for the core endpoints. So far there’s also oembed/1.0. Plugins can add their own namespaces – I imagine we’ll have wpcom/v2 or similar for WPCOM-specific endpoints like store. More info in the WP-API discovery docs.
- Then finally the path to the endpoint itself like/posts or /types.
```

With the version being further down the path, the other libraries like wpcom.js will need to be aware of how to properly build the paths depending on API version as well - this PR just adjusts the base path to be ready for WP-API v2 endpoints.

/cc @retrofox 