### PR TITLE
Better error messages for HTTP-level status errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "debug": "~2.2.0",
-    "superagent": "1.2.0"
+    "superagent": "1.2.0",
+    "wp-error": "^1.1.0"
   }
 }


### PR DESCRIPTION
Better error messages for HTTP-level status errors. Given a barebones script that will cause a 404:

``` js
var request = require('./');
request('/404', function (err, data) {
  if (err) throw err;
});
```

Previously the error message wouldn't contain any useful information:

```
$ node t
/Users/nrajlich/a8c/wpcom-xhr-request/t.js:6
  if (err) throw err;
           ^

Error
    at /Users/nrajlich/a8c/wpcom-xhr-request/index.js:123:11
    at Request.callback (/Users/nrajlich/a8c/wpcom-xhr-request/node_modules/superagent/lib/node/index.js:797:3)
    at Stream.<anonymous> (/Users/nrajlich/a8c/wpcom-xhr-request/node_modules/superagent/lib/node/index.js:990:12)
    at emitNone (events.js:72:20)
    at Stream.emit (events.js:166:7)
    at Unzip.<anonymous> (/Users/nrajlich/a8c/wpcom-xhr-request/node_modules/superagent/lib/node/utils.js:108:12)
    at emitNone (events.js:72:20)
    at Unzip.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at nextTickCallbackWith2Args (node.js:455:9)
```

Now, we get some more descriptive information to figure out what happened:

```
❯ node t
/Users/nrajlich/a8c/wpcom-xhr-request/t.js:6
  if (err) throw err;
           ^

NotFoundError: 404 status code for "GET /rest/v1/404"
    at /Users/nrajlich/a8c/wpcom-xhr-request/index.js:124:11
    at Request.callback (/Users/nrajlich/a8c/wpcom-xhr-request/node_modules/superagent/lib/node/index.js:797:3)
    at Stream.<anonymous> (/Users/nrajlich/a8c/wpcom-xhr-request/node_modules/superagent/lib/node/index.js:990:12)
    at emitNone (events.js:72:20)
    at Stream.emit (events.js:166:7)
    at Unzip.<anonymous> (/Users/nrajlich/a8c/wpcom-xhr-request/node_modules/superagent/lib/node/utils.js:108:12)
    at emitNone (events.js:72:20)
    at Unzip.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at nextTickCallbackWith2Args (node.js:455:9)
```

Note the:

> NotFoundError: 404 status code for "GET /rest/v1/404"

:kissing_cat: 