### PR TITLE
Prepare for new WP-API URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,6 @@ var proxyOrigin = 'https://public-api.wordpress.com';
 var defaultApiVersion = '1';
 
 /**
- * WP-API Namespaces
- */
-var wpApiNamespaces = ['wp'];
-
-/**
  * Performs an XMLHttpRequest against the WordPress.com REST API.
  *
  * @param {Object|String} params
@@ -59,8 +54,12 @@ function request (params, fn) {
 
   var basePath = '/rest/v' + apiVersion;
 
-  // if this is a wp-api request, adjust basePath
-  if ( apiNamespace && wpApiNamespaces.indexOf( apiNamespace ) !== -1 ) {
+  // If this is a WP-API request, adjust basePath
+  if ( apiNamespace && /\//.test( apiNamespace ) ) {
+    // New-style WP-API URL: /wpcom/v2/sites/%s/post-counts
+    basePath = '/' + apiNamespace;
+  } else if ( apiNamespace ) {
+    // Old-style WP-API URL (deprecated): /wp-json/sites/%s/wpcom/v2/post-counts
     basePath = '/wp-json';
   }
 


### PR DESCRIPTION
We're in the process of migrating WP-API URLs as follows (ref: pMz3w-5l5-p2)

```diff
- public-api.wordpress.com/wp-json/sites/4/wp/v2/types
+ public-api.wordpress.com/wp/v2/sites/4/types

- public-api.wordpress.com/wp-json/sites/4/wpcom/v2/post-counts
+ public-api.wordpress.com/wpcom/v2/sites/4/post-counts
```

For a short time, we'll need to support both URL patterns.  I propose to do this by detecting the presence of a `/` in the `apiNamespace` parameter.  Further reading on API namespaces:  http://v2.wp-api.org/extending/adding/#namespacing

I expect that client code will call API requests as follows:

```
this.wpcom.req.get( '/sites/%s/post-counts', { apiNamespace: 'wpcom/v2' } );
```

Then the transport library (such as this one or `rest-proxy`) will combine the namespace and the request path.

cc @timmyc @retrofox