### PR TITLE
Update version dependency for `wp-error`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "debug": "~2.2.0",
     "superagent": "1.2.0",
-    "wp-error": "^1.1.0"
+    "wp-error": "^1.3.0"
   }
 }


### PR DESCRIPTION
Version 1.3.0 handles an error where a null or undefined value passed into the `WPError()` constructor would throw a `TypeError` exception.

This change fixes that.