### PR TITLE
Fix sending Blob files

### DIFF
--- a/examples/browser/upload.html
+++ b/examples/browser/upload.html
@@ -1,60 +1,80 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>WordPress.com REST API XMLHttpRequest Media Upload Test Page</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<title>WordPress.com REST API XMLHttpRequest Media Upload Test Page</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   </head>
   <body>
-    <input type="file" id="file" multiple>
-    <script src="http://wzrd.in/standalone/wpcom-browser-auth@1.0.x"></script>
-    <script src="../../dist/wpcom-xhr-request.js"></script>
-    Select one or more files to upload to site ID: <strong id="site"></strong>
-    <script>
-      var auth = wpcomBrowserAuth.response();
+	<input type="file" id="file" multiple>
+	<script src="http://wzrd.in/standalone/wpcom-browser-auth@1.0.x"></script>
+	<script src="../../dist/wpcom-xhr-request.js"></script>
+	
+	<p>Select one or more files to upload to site ID: <strong id="site"></strong></p>
+	<div id="images"></div>
+	<script>
+		/* global WPCOMXhrHandler, wpcomBrowserAuth */
+		/* eslint-disable no-var, no-console, no-trailing-spaces, eol-last */
+		/* eslint no-undef: "error" */
 
-      function onchange (e) {
-        // construct a 2D `formData` array for the selected files
-        var formData = [];
-        for (var i = 0; i < e.target.files.length; i++) {
-          formData.push(['media[]', e.target.files[i]]);
-        }
-        console.log(formData);
+		const auth = wpcomBrowserAuth.response();
 
-        // do the API request through a CORS XHR request
-        var req = WPCOM.xhr({
-          authToken: auth.access_token,
-          path: '/sites/' + auth.site_id + '/media/new',
-          method: 'POST',
-          formData: formData
-        }, function(err, res){
-          console.error(arguments);
-          if (err) throw err;
-          console.log(res);
-        });
+		const inputElement = document.getElementById( 'file' );
+		const imagesPlaceholder = document.getElementById( 'images' );
+		const clientId = /calypso\.localhost/.test( document.location.hostname ) ? '51775' : '51777';
 
-        req.upload.addEventListener('progress', onprogress, false);
-      }
+		// INIT
+		if ( auth && auth.access_token ) {
+			boot();
+		} else {
+			// redirect to OAuth page
+			wpcomBrowserAuth.redirect( clientId );
+		}
 
-      function onprogress (e) {
-        if (e.lengthComputable) {
-          var percentComplete = e.loaded / e.total;
-          console.log(e.loaded, e.total, percentComplete);
-        } else {
-          // Unable to compute progress information since the total size is unknown
-        }
-      }
+		function boot() {
+			document.getElementById( 'site' ).innerHTML = auth.site_id;			
+			inputElement.onchange = onchange;
+		}
 
-      if (auth && auth.access_token) {
-        // OAuth response
-        document.getElementById('site').innerHTML = auth.site_id;
+		function onchange( e ) {
+			// construct a 2D `formData` array for the selected files
+			const formData = [];
+			for ( let i = 0; i < e.target.files.length; i++ ) {
+				formData.push( [ 'media[]', e.target.files[ i ] ] );
+			}
 
-        // select files on the "input" element
-        var input = document.getElementById('file');
-        input.onchange = onchange;
-      } else {
-        // redirect to OAuth page
-        wpcomBrowserAuth.redirect('37197');
-      }
-    </script>
+			const req = WPCOMXhrHandler( {
+				authToken: auth.access_token,
+				path: '/sites/' + auth.site_id + '/media/new',
+				apiVersion: '1.1',
+				method: 'POST',
+				formData: formData
+			}, function( err, { media } ) {
+				if ( err ) { 
+					throw err;
+				}
+
+				printUploadedImages( media );
+			} );
+
+			req.upload.addEventListener( 'progress', onprogress, false );
+		}
+
+		function printUploadedImages( media ) {
+			for ( let i = 0; i < media.length; i++ ) {
+				const img = media[ i ];
+				const { title, width, URL } = img;
+				imagesPlaceholder.innerHTML += `<img src="${ URL }" width="${ width }" title="${ title } " /><hr />`;
+			}
+		}
+
+		function onprogress( e ) {
+			if ( e.lengthComputable ) {
+				const percentComplete = e.loaded / e.total;
+				console.log( `${ percentComplete * 100 }% complete.` );
+			} else {
+				// Unable to compute progress information since the total size is unknown
+			}
+		}
+	</script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -86,6 +86,19 @@ const sendResponse = ( req, settings, fn ) => {
 };
 
 /**
+ * Returns `true` if `v` is a File Form Data, `false` otherwise.
+ *
+ * @param {Mixed} v - instance to analize
+ * @return {Boolean} `true` if `v` is a DOM File instance
+ * @private
+ */
+function isFile( v ) {
+	return v instanceof Object &&
+		'undefined' !== typeof( Blob ) &&
+		v.fileContents instanceof Blob;
+}
+
+/**
  * Performs an XMLHttpRequest against the WordPress.com REST API.
  *
  * @param {Object|String} options - `request path` or `request parameters`
@@ -161,7 +174,12 @@ export default function request( options, fn ) {
 			const key = data[ 0 ];
 			const value = data[ 1 ];
 			debug( 'adding FormData field %o: %o', key, value );
-			req.field( key, value );
+
+			if ( isFile( value ) ) {
+				req.attach( key, new File( [ value.fileContents ], value.fileName ) );
+			} else {
+				req.field( key, value );
+			}
 		}
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -556,7 +556,7 @@ describe( 'wpcom-xhr-request', () => {
 								// error
 								expect( error ).to.be.ok;
 								expect( error.name ).to.be.equal( 'UnauthorizedError' );
-								expect( error.message ).to.be.equal( 'You are not currently logged in.' );
+								expect( error.message ).to.be.equal( 'That API call requires authentication against the correct blog.' );
 								expect( error.statusCode ).to.be.equal( 401 );
 
 								// body
@@ -635,7 +635,7 @@ describe( 'wpcom-xhr-request', () => {
 								// error
 								expect( error ).to.be.ok;
 								expect( error.name ).to.be.equal( 'UnauthorizedError' );
-								expect( error.message ).to.be.equal( 'You are not currently logged in.' );
+								expect( error.message ).to.be.equal( 'That API call requires authentication against the correct blog.' );
 								expect( error.statusCode ).to.be.equal( 401 );
 
 								// body
@@ -921,7 +921,7 @@ describe( 'wpcom-xhr-request', () => {
 							// error
 							expect( error ).to.be.ok;
 							expect( error.name ).to.be.equal( 'NotFoundError' );
-							expect( error.message ).to.be.equal( 'Invalid post id.' );
+							expect( error.message ).to.be.equal( 'Invalid post ID.' );
 							expect( error.statusCode ).to.be.equal( 404 );
 
 							// body
@@ -998,7 +998,7 @@ describe( 'wpcom-xhr-request', () => {
 							// error
 							expect( error ).to.be.ok;
 							expect( error.name ).to.be.equal( 'NotFoundError' );
-							expect( error.message ).to.be.equal( 'Invalid post id.' );
+							expect( error.message ).to.be.equal( 'Invalid post ID.' );
 							expect( error.statusCode ).to.be.equal( 404 );
 
 							// body

--- a/test/util.js
+++ b/test/util.js
@@ -16,7 +16,7 @@ try {
 
 // grab token even from config file or TOKEN env var
 const { token } = config;
-export const authToken = token || process.env.TOKEN;
+export const authToken = process.env.TOKEN || token;
 
 export const siteDomain = 'wpcomjstest.wordpress.com';
 export const wporgProxyOrigin = 'http://retrofocs.wpsandbox.me/wp-json';


### PR DESCRIPTION
On Calypso's Desktop App, when performing a file upload, the body of the request is not filled properly. We get something like:

```
------WebKitFormBoundaryrAdCjKcx9SfAPEgk
Content-Disposition: form-data; name="media[]"

[object Object]
------WebKitFormBoundaryrAdCjKcx9SfAPEgk—
```

In this PR, I'm trying to fix this by using superagent's attach method with a file object as a value.
I'm not really familiar with the library or the different use-case, thus, any feedback is appreciated. 

My question is, are we using this library somewhere for file uploads? (aside from the new calypso's site icon config)