### PR TITLE
Upgrade superagent, debug, webpack and serve packages

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,20 +1,10 @@
 module.exports = {
 	entry: __dirname + '/../build/index.js',
-
-	node: {
-		fs: 'empty'
-	},
-
 	output: {
 		path: __dirname + '/browser/dist/',
 		filename: 'wpcom-xhr-request.js',
 		libraryTarget: 'var',
 		library: 'WPCOMXhrHandler'
 	},
-
-	resolve: {
-		extensions: [ '', '.js' ]
-	},
-
 	devtool: 'sourcemap'
 };

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     ]
   },
   "dependencies": {
-    "debug": "~2.2.0",
-    "superagent": "^2.1.0",
+    "debug": "^3.1.0",
+    "superagent": "^3.8.3",
     "wp-error": "^1.3.0"
   },
   "devDependencies": {
@@ -49,7 +49,8 @@
     "eslint": "^3.1.1",
     "mocha": "^2.5.3",
     "n8-make": "^1.5.0",
-    "serve": "^1.4.0",
-    "webpack": "^1.13.1"
+    "serve": "^9.2.0",
+    "webpack": "^4.16.1",
+    "webpack-cli": "^3.1.0"
   }
 }


### PR DESCRIPTION
Upgrades superagent and debug (production dependencies) and webpack and serve (dev dependencies) to their latest versions.

Also removes some redundant code from the Webpack config file.

The superagent and debug upgrades will be very useful in Calypso.

There are other possible upgrades of the very outdated build pipeline: Babel 7, Mocha, ESLint, maybe abandon `n8-make` and replace it with a simple Makefile... But my main goal was to upgrade the production deps and I didn't want to enter any rabbit holes.

**How to test:**
I did `make examples` and tested the _blog.wordpress.com.html_ and _freshly-pressed.html_ example pages. They should load responses from the WP.com server and display them.

I didn't run any tests that require a valid OAuth token.
