### PR TITLE
Add babel-runtime as dependency to package.json

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.1.3 / 2019-04-03
+==================
+
+ * Add babel-runtime as dependency to package.json
+
 1.1.2 / 2018-07-23
 ==================
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "debug": "^3.1.0",
     "superagent": "^3.8.3",
     "wp-error": "^1.3.0"


### PR DESCRIPTION
The package requires the `babel-runtime/core-js/object/assign` module, but it's not specified as dependency. That becomes a problem when a project that uses `wpcom-xhr-request` doesn't depend on `babel-runtime` itself. Then the `babel-runtime` package doesn't get installed.