### PR TITLE
Add support for streaming application/x-ndjson responses

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.2.0 / 2020-12-11
+==================
+
+ * Add support for processing streamed `application/x-ndjson` responses
+
 1.1.3 / 2019-04-03
 ==================
 

--- a/index.js
+++ b/index.js
@@ -143,9 +143,10 @@ const sendResponse = ( req, settings, fn ) => {
 
 				lastLine = target.response.slice( start, stop );
 
+				// Parse the response chunk as JSON, ignoring trailing carriage returns.
 				// Note: not ignoring empty lines.
 				// <https://github.com/ndjson/ndjson-spec/blob/1.0/README.md#32-parsing>
-				const record = JSON.parse( lastLine.trim() );
+				const record = JSON.parse( lastLine );
 
 				// Non-last lines should have .status == 100.
 				if ( record.status < 200 ) {
@@ -161,7 +162,7 @@ const sendResponse = ( req, settings, fn ) => {
 		// Parse the last response chunk as above, but pass it to the higher layers as The Response.
 		// Note: not ignoring empty lines.
 		// <https://github.com/ndjson/ndjson-spec/blob/1.0/README.md#32-parsing>
-		req.parse( () => JSON.parse( lastLine.trim() ) );
+		req.parse( () => JSON.parse( lastLine ) );
 	}
 
 	return req;

--- a/index.js
+++ b/index.js
@@ -120,6 +120,10 @@ const sendResponse = ( req, settings, fn ) => {
 		let lastLine = null;
 		let start = 0;
 
+		// A progress event is guaranteed to be fired after the end of the response body, so we
+		// should never miss any data.
+		// <https://xhr.spec.whatwg.org/#the-send()-method>
+		// <https://xhr.spec.whatwg.org/#handle-response-end-of-body>
 		req.xhr.addEventListener( 'progress', ( { target } ) => {
 			// Don’t use ProgressEvent#loaded in this algorithm. It measures progress in octets,
 			// while we’re working with text that has already been decoded from UTF-8 into a string

--- a/index.js
+++ b/index.js
@@ -112,13 +112,6 @@ const sendResponse = ( req, settings, fn ) => {
 		// <https://xhr.spec.whatwg.org/#the-response-attribute>
 		req.xhr.responseType = 'text';
 
-		// Force the response to be treated as UTF-8. This is easier than the x-user-defined trick
-		// that would otherwise be needed to access the raw binary response body.
-		// <https://xhr.spec.whatwg.org/#final-charset>
-		// <https://github.com/ndjson/ndjson-spec/blob/1.0/README.md#31-serialization>
-		// <https://stackoverflow.com/a/33042003>
-		req.xhr.overrideMimeType( 'application/x-ndjson; charset=utf-8' );
-
 		// Find response chunks that end in a newline (possibly preceded by a carriage return), then
 		// for each chunk except the last, parse it as JSON and pass that to onStreamRecord.
 		// <https://github.com/ndjson/ndjson-spec/blob/1.0/README.md#31-serialization>

--- a/index.js
+++ b/index.js
@@ -132,9 +132,8 @@ const sendResponse = ( req, settings, fn ) => {
 			// while we’re working with text that has already been decoded from UTF-8 into a string
 			// that can only be indexed in UTF-16 code units. Reconciling this difference is not
 			// worth the effort, and might even be impossible if there were encoding errors.
-			let stop;
 			while ( true ) {
-				stop = target.response.indexOf( '\n', start );
+				const stop = target.response.indexOf( '\n', start );
 
 				if ( stop < 0 ) {
 					// Leave start untouched for the next progress event, waiting for the newline

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "api",
     "oauth"
   ],
-  "version": "1.1.3",
+  "version": "1.2.0",
   "scripts": {
     "pretest": "make build",
     "test": "mocha --timeout 120s --slow 3s --bail --reporter spec --compilers js:babel-register test",


### PR DESCRIPTION
This patch adds two options to help Calypso consume the Jetpack credentials API in the new step-by-step progress mode.

**processResponseInStreamMode** tells the library to handle responses with Content-Type: [application/x-ndjson](http://ndjson.org/) specially, by streaming the records and diverting all but the last to onStreamRecord (with the help of envelopes).

**onStreamRecord** is a callback for each record except the last.

See [wp-calypso#47898](https://github.com/Automattic/wp-calypso/pull/47898) for more details and testing notes.