### PR TITLE
Fix request URL when API namespace has no leading slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,30 @@
-
 /**
  * Module dependencies.
  */
-import WPError from 'wp-error';
-import superagent from 'superagent';
-import debugFactory from 'debug';
+import WPError from "wp-error";
+import superagent from "superagent";
+import debugFactory from "debug";
 
 /**
  * Module variables
  */
-const debug = debugFactory( 'wpcom-xhr-request' );
+const debug = debugFactory("wpcom-xhr-request");
 
 /**
  * Defauts
  */
 const defaults = {
-	apiVersion: '1',
-	apiNamespace: 'wp/v2',
-	authToken: null,
-	body: null,
-	formData: null,
-	headers: null,
-	method: 'get',
-	query: null,
-	processResponseInEnvelopeMode: true,
-	proxyOrigin: 'https://public-api.wordpress.com',
-	url: ''
+  apiVersion: "1",
+  apiNamespace: "wp/v2",
+  authToken: null,
+  body: null,
+  formData: null,
+  headers: null,
+  method: "get",
+  query: null,
+  processResponseInEnvelopeMode: true,
+  proxyOrigin: "https://public-api.wordpress.com",
+  url: "",
 };
 
 /**
@@ -36,53 +35,49 @@ const defaults = {
  * @param  {Function} fn - callback function
  * @return {Superagent} request instance
  */
-const sendResponse = ( req, settings, fn ) => {
-	const {
-		isEnvelopeMode,
-		isRestAPI,
-		processResponseInEnvelopeMode
-	} = settings;
+const sendResponse = (req, settings, fn) => {
+  const { isEnvelopeMode, isRestAPI, processResponseInEnvelopeMode } = settings;
 
-	req.end( ( error, response ) => {
-		if ( error && ! response ) {
-			return fn( error );
-		}
+  req.end((error, response) => {
+    if (error && !response) {
+      return fn(error);
+    }
 
-		let { body, headers, statusCode } = response;
+    let { body, headers, statusCode } = response;
 
-		const { ok } = response;
-		const { path, method } = response.req;
-		headers.status = statusCode;
+    const { ok } = response;
+    const { path, method } = response.req;
+    headers.status = statusCode;
 
-		if ( ok ) {
-			if ( isEnvelopeMode && processResponseInEnvelopeMode ) {
-				// override `error`, body` and `headers`
-				if ( isRestAPI ) {
-					headers = body.headers;
-					statusCode = body.code;
-					body = body.body;
-				} else {
-					headers = body.headers;
-					statusCode = body.status;
-					body = body.body;
-				}
+    if (ok) {
+      if (isEnvelopeMode && processResponseInEnvelopeMode) {
+        // override `error`, body` and `headers`
+        if (isRestAPI) {
+          headers = body.headers;
+          statusCode = body.code;
+          body = body.body;
+        } else {
+          headers = body.headers;
+          statusCode = body.status;
+          body = body.body;
+        }
 
-				headers.status = statusCode;
+        headers.status = statusCode;
 
-				if ( null !== statusCode && 2 !== Math.floor( statusCode / 100 ) ) {
-					debug( 'Error detected!' );
-					const wpe = WPError( { path, method }, statusCode, body );
-					return fn( wpe, null, headers );
-				}
-			}
-			return fn( null, body, headers );
-		}
+        if (null !== statusCode && 2 !== Math.floor(statusCode / 100)) {
+          debug("Error detected!");
+          const wpe = WPError({ path, method }, statusCode, body);
+          return fn(wpe, null, headers);
+        }
+      }
+      return fn(null, body, headers);
+    }
 
-		const wpe = WPError( { path, method }, statusCode, body );
-		return fn( wpe, null, headers );
-	} );
+    const wpe = WPError({ path, method }, statusCode, body);
+    return fn(wpe, null, headers);
+  });
 
-	return req;
+  return req;
 };
 
 /**
@@ -92,10 +87,12 @@ const sendResponse = ( req, settings, fn ) => {
  * @return {Boolean} `true` if `v` is a DOM File instance
  * @private
  */
-function isFile( v ) {
-	return v instanceof Object &&
-		'undefined' !== typeof( Blob ) &&
-		v.fileContents instanceof Blob;
+function isFile(v) {
+  return (
+    v instanceof Object &&
+    "undefined" !== typeof Blob &&
+    v.fileContents instanceof Blob
+  );
 }
 
 /**
@@ -106,102 +103,104 @@ function isFile( v ) {
  * @return { XHR } xhr instance
  * @api public
  */
-export default function request( options, fn ) {
-	if ( 'string' === typeof options ) {
-		options = { path: options };
-	}
+export default function request(options, fn) {
+  if ("string" === typeof options) {
+    options = { path: options };
+  }
 
-	const settings = Object.assign( {}, defaults, options );
+  const settings = Object.assign({}, defaults, options);
 
-	// is REST-API api?
-	settings.isRestAPI = options.apiNamespace === undefined;
+  // is REST-API api?
+  settings.isRestAPI = options.apiNamespace === undefined;
 
-	// normalize request-method name
-	settings.method = settings.method.toLowerCase();
+  // normalize request-method name
+  settings.method = settings.method.toLowerCase();
 
-	const {
-		apiNamespace,
-		apiVersion,
-		authToken,
-		body,
-		formData,
-		headers,
-		isRestAPI,
-		method,
-		query,
-		proxyOrigin
-	} = settings;
+  const {
+    apiNamespace,
+    apiVersion,
+    authToken,
+    body,
+    formData,
+    headers,
+    isRestAPI,
+    method,
+    query,
+    proxyOrigin,
+  } = settings;
 
-	// request base path
-	let basePath;
+  // request base path
+  let basePath;
 
-	if ( isRestAPI ) {
-		basePath = `/rest/v${ apiVersion }`;
-	} else if ( apiNamespace && /\//.test( apiNamespace ) ) {
-		basePath = '/' + apiNamespace;	// wpcom/v2
-	} else {
-		basePath = '/wp-json'; // /wp-json/sites/%s/wpcom/v2 (deprecated)
-	}
+  if (isRestAPI) {
+    basePath = `/rest/v${apiVersion}`;
+  } else if (apiNamespace) {
+    basePath = /\//.test(apiNamespace) ? apiNamespace : `/${apiNamespace}`;
+  } else {
+    basePath = "/wp-json"; // /wp-json/sites/%s/wpcom/v2 (deprecated)
+  }
 
-	// Envelope mode FALSE as default
-	settings.isEnvelopeMode = false;
+  // Envelope mode FALSE as default
+  settings.isEnvelopeMode = false;
 
-	settings.url = proxyOrigin + basePath + settings.path;
-	debug( 'API URL: %o', settings.url );
+  settings.url = proxyOrigin + basePath + settings.path;
+  debug("API URL: %o", settings.url);
 
-	// create HTTP Request instance
-	const req = superagent[ method ]( settings.url );
+  // create HTTP Request instance
+  const req = superagent[method](settings.url);
 
-	// querystring
-	if ( query ) {
-		req.query( query );
-		debug( 'API send URL querystring: %o', query );
+  // querystring
+  if (query) {
+    req.query(query);
+    debug("API send URL querystring: %o", query);
 
-		settings.isEnvelopeMode = isRestAPI ? query.http_envelope : query._envelope;
-		debug( 'envelope mode: %o', settings.isEnvelopeMode );
-	}
+    settings.isEnvelopeMode = isRestAPI ? query.http_envelope : query._envelope;
+    debug("envelope mode: %o", settings.isEnvelopeMode);
+  }
 
-	// body
-	if ( body && formData ) {
-		debug( 'API ignoring body because formData is set. They cannot both be used together.' );
-	}
-	if ( body && ! formData ) {
-		req.send( body );
-		debug( 'API send POST body: %o', body );
-	}
+  // body
+  if (body && formData) {
+    debug(
+      "API ignoring body because formData is set. They cannot both be used together."
+    );
+  }
+  if (body && !formData) {
+    req.send(body);
+    debug("API send POST body: %o", body);
+  }
 
-	// POST FormData (for `multipart/form-data`, usually a file upload)
-	if ( formData ) {
-		for ( let i = 0; i < formData.length; i++ ) {
-			const data = formData[ i ];
-			const key = data[ 0 ];
-			const value = data[ 1 ];
-			debug( 'adding FormData field %o: %o', key, value );
+  // POST FormData (for `multipart/form-data`, usually a file upload)
+  if (formData) {
+    for (let i = 0; i < formData.length; i++) {
+      const data = formData[i];
+      const key = data[0];
+      const value = data[1];
+      debug("adding FormData field %o: %o", key, value);
 
-			if ( isFile( value ) ) {
-				req.attach( key, new File( [ value.fileContents ], value.fileName ) );
-			} else {
-				req.field( key, value );
-			}
-		}
-	}
+      if (isFile(value)) {
+        req.attach(key, new File([value.fileContents], value.fileName));
+      } else {
+        req.field(key, value);
+      }
+    }
+  }
 
-	// headers
-	if ( headers ) {
-		req.set( headers );
-		debug( 'adding HTTP headers: %o', headers );
-	}
+  // headers
+  if (headers) {
+    req.set(headers);
+    debug("adding HTTP headers: %o", headers);
+  }
 
-	if ( authToken ) {
-		req.set( 'Authorization', `Bearer ${ authToken }` );
-	}
+  if (authToken) {
+    req.set("Authorization", `Bearer ${authToken}`);
+  }
 
-	if ( ! req.get( 'Accept' ) ) {
-		// set a default "Accept" header preferring a JSON response
-		req.set( 'Accept', '*/json,*/*' );
-	}
+  if (!req.get("Accept")) {
+    // set a default "Accept" header preferring a JSON response
+    req.set("Accept", "*/json,*/*");
+  }
 
-	sendResponse( req, settings, fn );
+  sendResponse(req, settings, fn);
 
-	return req.xhr;
+  return req.xhr;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes an issue that causes the library to not consider the API namespace when building the URL, if the namespace doesn't start with a leading slash.

Using the following options when calling `request` (`index.js`):
```
{
	apiNamespace: 'wpcom',
	method: 'GET',
	path: '/v2/experiments/0.1.0/assignments/calypso',
}
```
URL is `https://public-api.wordpress.com/wp-json/v2/experiments/0.1.0/assignments/calypso`, while it should be `https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso`.

### Testing instructions

- Review code
- Check that tests still pass