### PR TITLE
Fix request URL when API namespace has no leading slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,8 +137,8 @@ export default function request( options, fn ) {
 
 	if ( isRestAPI ) {
 		basePath = `/rest/v${ apiVersion }`;
-	} else if ( apiNamespace && /\//.test( apiNamespace ) ) {
-		basePath = '/' + apiNamespace;	// wpcom/v2
+	} else if (apiNamespace) {
+		basePath = /\//.test(apiNamespace) ? apiNamespace : `/${apiNamespace}`;
 	} else {
 		basePath = '/wp-json'; // /wp-json/sites/%s/wpcom/v2 (deprecated)
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes an issue that causes the library to not consider the API namespace when building the URL, if the namespace doesn't start with a leading slash.

Using the following options when calling `request` (`index.js`):
```
{
	apiNamespace: 'wpcom',
	method: 'GET',
	path: '/v2/experiments/0.1.0/assignments/calypso',
}
```
URL is `https://public-api.wordpress.com/wp-json/v2/experiments/0.1.0/assignments/calypso`, while it should be `https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso`.

### Testing instructions

- Review code
- Check that tests still pass