### PR TITLE
Improve/use spread operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ export default function request( options, fn ) {
 		options = { path: options };
 	}
 
-	const settings = Object.assign( {}, defaults, options );
+	const settings = { ...defaults, ...options };
 
 	// is REST-API api?
 	settings.isRestAPI = options.apiNamespace === undefined;


### PR DESCRIPTION
Use _spread operator_ (standardized in **ES2018**) instead of the old `Object.assign` method.
Advantages of using the spread operator:
- Less verbose
- Benefits in performance